### PR TITLE
Use full path name for negative files

### DIFF
--- a/prep.py
+++ b/prep.py
@@ -87,7 +87,7 @@ if command == "neg":
 
         shutil.copy2(INPUT_NEGATIVE_DIR + neg_file, OUTPUT_NEGATIVE_DIR + neg_file )
 
-        f.write(neg_file + "\n")
+        f.write(OUTPUT_NEGATIVE_DIR + neg_file + "\n")
 
 
     f.close()


### PR DESCRIPTION
For me, if negative.txt doesn't have full path directories, the `opencv_traincascade` command fails with:

```
===== TRAINING 0-stage =====
<BEGIN
POS count : consumed   399 : 399
Train dataset for temp stage can not be filled. Branch training terminated.
Cascade classifier can't be trained. Check the used training parameters.
```

This change fixes that issue